### PR TITLE
Fix/update api params

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ environment variables.
       cherryservers.cloud.server:
         project_id: 216063
         region: "eu_nord_1"
-        plan: "cloud_vps_1"
+        plan: "B1-1-1gb-20s-shared"
         auth_token: "my-auth-token-goes-here"
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ environment variables.
     - name: Create a server
       cherryservers.cloud.server:
         project_id: 216063
-        region: "eu_nord_1"
+        region: "LT-Siauliai"
         plan: "B1-1-1gb-20s-shared"
         auth_token: "my-auth-token-goes-here"
 ```

--- a/plugins/inventory/cherryservers.py
+++ b/plugins/inventory/cherryservers.py
@@ -70,7 +70,7 @@ auth_token: "my_api_key"
 plugin: cherryservers.cloud.cherryservers
 project_id: 123456
 auth_token: "my_api_key"
-region: "eu_nord_1"
+region: "LT-Siauliai"
 tags:
   env: "test"
 

--- a/plugins/modules/floating_ip.py
+++ b/plugins/modules/floating_ip.py
@@ -81,7 +81,7 @@ EXAMPLES = r"""
 - name: Create a floating IP
   cherryservers.cloud.floating_ip:
     project_id: 213668
-    region: "eu_nord_1"
+    region: "LT-Siauliai"
     target_server_id: 590738
     ptr_record: "moduletestptr"
     a_record: "moduletesta"
@@ -140,7 +140,7 @@ cherryservers_floating_ip:
       description: Slug of the region to which the IP belongs to.
       returned: always
       type: str
-      sample: "eu_nord_1"
+      sample: "LT-Siauliai"
     tags:
       description: Tags of the floating IP.
       returned: always

--- a/plugins/modules/floating_ip_info.py
+++ b/plugins/modules/floating_ip_info.py
@@ -72,7 +72,7 @@ EXAMPLES = r"""
 - name: 'Get all floating IPs in the EU Nord-1 region, that have the env: dev tag'
   cherryservers.cloud.floating_ip_info:
     auth_token: "{{ auth_token }}"
-    region: "eu_nord_1"
+    region: "LT-Siauliai"
     project_id: 123456
     tags:
       env: "dev"
@@ -115,7 +115,7 @@ cherryservers_floating_ips:
       description: Slug of the region to which the IP belongs to.
       returned: always
       type: str
-      sample: "eu_nord_1"
+      sample: "LT-Siauliai"
     tags:
       description: Tags of the floating IP.
       returned: always

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -153,7 +153,7 @@ EXAMPLES = r"""
     project_id: 213668
     region: "LT-Siauliai"
     plan: "B1-1-1gb-20s-shared"
-    image: "fedora_39_64bit"
+    image: "debian_12_64bit"
     ssh_keys: [1234]
     hostname: "cantankerous-crow"
     extra_ip_addresses: ["5ab09cbd-80f2-8fcd-064e-c260e44b0ae9"]
@@ -184,7 +184,7 @@ EXAMPLES = r"""
     tags:
       env: "test-upd"
     active_timeout: 600
-    image: "fedora_39_64bit"
+    image: "debian_12_64bit"
     ssh_keys: [7630]
     user_data: "{{ userdata['content']}}"
     allow_reinstall: true
@@ -217,7 +217,7 @@ cherryservers_server:
       description: Server OS image slug.
       returned: always
       type: str
-      sample: "fedora_39_64bit"
+      sample: "debian_12_64bit"
     ip_addresses:
       description: Server IP addresses.
       returned: always

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -137,8 +137,8 @@ EXAMPLES = r"""
   cherryservers.cloud.server:
     state: "active"
     project_id: 213668
-    region: "eu_nord_1"
-    plan: "cloud_vps_1"
+    region: "LT-Siauliai"
+    plan: "B1-1-1gb-20s-shared"
     tags:
       env: "test"
     active_timeout: 600
@@ -151,8 +151,8 @@ EXAMPLES = r"""
 - name: Create a server with more options
   cherryservers.cloud.server:
     project_id: 213668
-    region: "eu_nord_1"
-    plan: "cloud_vps_1"
+    region: "LT-Siauliai"
+    plan: "B1-1-1gb-20s-shared"
     image: "fedora_39_64bit"
     ssh_keys: [1234]
     hostname: "cantankerous-crow"
@@ -258,7 +258,7 @@ cherryservers_server:
       description: Slug of the server plan.
       returned: always
       type: str
-      sample: "cloud_vps_1"
+      sample: "B1-1-1gb-20s-shared"
     project_id:
       description: Cherry Servers project ID, associated with the server.
       returned: always
@@ -268,7 +268,7 @@ cherryservers_server:
       description: Slug of the server region.
       returned: always
       type: str
-      sample: "eu_nord_1"
+      sample: "LT-Siauliai"
     spot_market:
       description: Whether the server is a spot market instance.
       returned: always

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -89,7 +89,7 @@ EXAMPLES = r"""
 - name: Get servers by plan
   cherryservers.cloud.server_info:
     project_id: "213668"
-    plan: cloud_vps_1
+    plan: "B1-1-1gb-20s-shared"
   register: result
 """
 
@@ -155,7 +155,7 @@ cherryservers_servers:
       description: Slug of the server plan.
       returned: always
       type: str
-      sample: "cloud_vps_1"
+      sample: "B1-1-1gb-20s-shared"
     project_id:
       description: Cherry Servers project ID, associated with the server.
       returned: always

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -80,7 +80,7 @@ EXAMPLES = r"""
 
 - name: 'Get all servers in the EU Nord-1 region, that have the env: test-upd tag'
   cherryservers.cloud.server_info:
-    region: "eu_nord_1"
+    region: "LT-Siauliai"
     project_id: "213668"
     tags:
       env: "test-upd"
@@ -165,7 +165,7 @@ cherryservers_servers:
       description: Slug of the server region.
       returned: always
       type: str
-      sample: "eu_nord_1"
+      sample: "LT-Siauliai"
     spot_market:
       description: Whether the server is a spot market instance.
       returned: always

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -114,7 +114,7 @@ cherryservers_servers:
       description: Server OS image slug.
       returned: always
       type: str
-      sample: "fedora_39_64bit"
+      sample: "debian_12_64bit"
     ip_addresses:
       description: Server IP addresses.
       returned: always

--- a/plugins/modules/storage.py
+++ b/plugins/modules/storage.py
@@ -81,14 +81,14 @@ EXAMPLES = r"""
   cherryservers.cloud.storage:
     state: "detached"
     project_id: 213668
-    region: "eu_nord_1"
+    region: "LT-Siauliai"
     size: 1
   register: result
 
 - name: Create an attached storage volume
   cherryservers.cloud.storage:
     project_id: 213668
-    region: "eu_nord_1"
+    region: "LT-Siauliai"
     size: 1
     target_server_id: 596908
   register: result
@@ -115,7 +115,7 @@ cherryservers_storage:
       description: Slug of the region that the EBS volume belongs to.
       returned: always
       type: str
-      sample: "eu_nord_1"
+      sample: "LT-Siauliai"
     size:
       description: Size of the volume, in GB.
       returned: always

--- a/plugins/modules/storage_info.py
+++ b/plugins/modules/storage_info.py
@@ -95,7 +95,7 @@ cherryservers_storages:
       description: Slug of the region that the EBS volume belongs to.
       returned: always
       type: str
-      sample: "eu_nord_1"
+      sample: "LT-Siauliai"
     size:
       description: Size of the volume, in GB.
       returned: always

--- a/tests/integration/targets/floating_ip/defaults/main.yml
+++ b/tests/integration/targets/floating_ip/defaults/main.yml
@@ -1,4 +1,4 @@
-fip_region: "eu_nord_1"
+fip_region: "LT-Siauliai"
 server_plan: "B1-1-1gb-20s-shared"
 
 fip_tags_basic:

--- a/tests/integration/targets/floating_ip/defaults/main.yml
+++ b/tests/integration/targets/floating_ip/defaults/main.yml
@@ -1,5 +1,5 @@
 fip_region: "eu_nord_1"
-server_plan: "cloud_vps_1"
+server_plan: "B1-1-1gb-20s-shared"
 
 fip_tags_basic:
   env: "ansupdtestbasic"

--- a/tests/integration/targets/floating_ip_info/defaults/main.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main.yml
@@ -1,4 +1,4 @@
-fip_region: "eu_nord_1"
+fip_region: "LT-Siauliai"
 fip_tags:
   env: "ansible-fip-info-test"
 

--- a/tests/integration/targets/floating_ip_info/defaults/main.yml
+++ b/tests/integration/targets/floating_ip_info/defaults/main.yml
@@ -2,4 +2,4 @@ fip_region: "eu_nord_1"
 fip_tags:
   env: "ansible-fip-info-test"
 
-server_plan: "cloud_vps_1"
+server_plan: "B1-1-1gb-20s-shared"

--- a/tests/integration/targets/server/defaults/main.yml
+++ b/tests/integration/targets/server/defaults/main.yml
@@ -1,5 +1,5 @@
 # All servers use these.
-server_region: "eu_nord_1"
+server_region: "LT-Siauliai"
 server_plan: "B1-1-1gb-20s-shared"
 
 # For the basic server test.

--- a/tests/integration/targets/server/defaults/main.yml
+++ b/tests/integration/targets/server/defaults/main.yml
@@ -1,6 +1,6 @@
 # All servers use these.
 server_region: "eu_nord_1"
-server_plan: "cloud_vps_1"
+server_plan: "B1-1-1gb-20s-shared"
 
 # For the basic server test.
 server_update_hostname: "ansible-server-update-test"

--- a/tests/integration/targets/server_info/defaults/main.yml
+++ b/tests/integration/targets/server_info/defaults/main.yml
@@ -1,5 +1,5 @@
 server_region: "eu_nord_1"
-server_plan: "cloud_vps_1"
+server_plan: "B1-1-1gb-20s-shared"
 
 server_tags:
   env: "server-info-test"

--- a/tests/integration/targets/server_info/defaults/main.yml
+++ b/tests/integration/targets/server_info/defaults/main.yml
@@ -1,4 +1,4 @@
-server_region: "eu_nord_1"
+server_region: "LT-Siauliai"
 server_plan: "B1-1-1gb-20s-shared"
 
 server_tags:

--- a/tests/integration/targets/storage/defaults/main.yml
+++ b/tests/integration/targets/storage/defaults/main.yml
@@ -1,5 +1,5 @@
 storage_size: 1
-storage_region: "eu_nord_1"
+storage_region: "LT-Siauliai"
 storage_description: "storage-test"
 
 storage_updated_description: "storage-update-test"

--- a/tests/integration/targets/storage_info/defaults/main.yml
+++ b/tests/integration/targets/storage_info/defaults/main.yml
@@ -1,3 +1,3 @@
 storage_size: 1
-storage_region: "eu_nord_1"
+storage_region: "LT-Siauliai"
 storage_description: "storage-info-test-basic"


### PR DESCRIPTION
Stop using deprecated API parameters for region, plan and image slugs in examples and testing.