### PR TITLE
feat!: drop python 3.9

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         versions:
           - ansible: stable-2.14
-            python: "3.9"
+            python: "3.10"
         module:
           - sshkey_info
           - sshkey

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cherry Servers Ansible collection for managing infrastructure and resources.
 ### Requirements
 
 - ansible-core >= 2.14
-- python >= 3.9
+- python >= 3.10
 
 ### Installation
 

--- a/changelogs/fragments/drop-support-for-python-3.9.yaml
+++ b/changelogs/fragments/drop-support-for-python-3.9.yaml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for Python 3.9. This is required to drop support for ansible-core 2.15, which is at EOF.

--- a/plugins/doc_fragments/cherryservers.py
+++ b/plugins/doc_fragments/cherryservers.py
@@ -14,7 +14,7 @@ class ModuleDocFragment:  # pylint: disable=missing-class-docstring, too-few-pub
         type: str
 
     requirements:
-      - python >= 3.9
+      - python >= 3.10
 
     seealso:
       - name: Cherry Servers API documentation

--- a/plugins/inventory/cherryservers.py
+++ b/plugins/inventory/cherryservers.py
@@ -12,7 +12,7 @@ author:
   - Martynas Deveikis (@caliban0)
 version_added: "0.1.0"
 requirements:
-  - python >= 3.9
+  - python >= 3.10
 extends_documentation_fragment:
   - inventory_cache
   - constructed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 ansible-core = "^2.15"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -7,7 +7,7 @@ modules:
   # Configuration for modules/module_utils.
   # These settings do not apply to other content in the collection.
 
-  python_requires: ~= 3.9
+  python_requires: ~= 3.10
   # Python versions supported by modules/module_utils.
   # This setting is required.
   #


### PR DESCRIPTION
Drop support for Python 3.9. This is required to drop support for ansible-core 2.15, which is at EOF.
Based on https://github.com/cherryservers/ansible-collection-cherryservers/pull/27.