### PR TITLE
feat!: drop support for ansible-core older than 2.16

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - ansible: stable-2.14
+          - ansible: stable-2.16
             python: "3.10"
         module:
           - sshkey_info

--- a/.github/workflows/sanity-tests.yml
+++ b/.github/workflows/sanity-tests.yml
@@ -11,10 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - ansible: stable-2.14
-          - ansible: stable-2.15
           - ansible: stable-2.16
           - ansible: stable-2.17
+          - ansible: stable-2.18
           - ansible: devel
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cherry Servers Ansible collection for managing infrastructure and resources.
 
 ### Requirements
 
-- ansible-core >= 2.14
+- ansible-core >= 2.16
 - python >= 3.10
 
 ### Installation

--- a/changelogs/fragments/drop-support-for-ansible-2.16.yaml
+++ b/changelogs/fragments/drop-support-for-ansible-2.16.yaml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Drop support for ansible-core 2.16. This drops support for Python 3.9 as well, since ansible-core 2.16 requires at least 3.10.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: '>=2.16.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
-ansible-core = "^2.15"
+ansible-core = "^2.16"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"


### PR DESCRIPTION
Since ansible-core 2.15 is at EOF, drop support for it and any prior ansible-core versions.

Based on https://github.com/cherryservers/ansible-collection-cherryservers/pull/28.