### PR TITLE
Deprecate `auth_token`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: cherryservers/ansible-test-gh-action@ef40f85a28ca0a14060dab06bb752fb9acea2376 # v1.18.0
         with:
           pre-test-cmd: >-
-            CHERRY_AUTH_TOKEN=${{ secrets.CHERRY_AUTH_TOKEN }}
+            CHERRY_API_KEY=${{ secrets.CHERRY_AUTH_TOKEN }}
             CHERRY_PROJECT_ID=${{ secrets.CHERRY_PROJECT_ID }}
             CHERRY_BAREMETAL_SERVER_ID=${{ secrets.CHERRY_BAREMETAL_SERVER_ID }}
             CHERRY_TEAM_ID=${{ secrets.CHERRY_TEAM_ID }}

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ ansible-galaxy collection install cherryservers.cloud
 
 ### Usage
 
-Before using the collection, you need to generate an API token from
+Before using the collection, you need to generate an API key from
 the [Cherry Servers client portal](https://portal.cherryservers.com/settings/api-keys).
-You can supply the token with the `auth_token` attribute or by setting `CHERRY_AUTH_TOKEN` (or `CHERRY_AUTH_KEY`)
-environment variables.
+You can supply the API key with the `api_key` attribute or by setting the `CHERRY_API_KEY` environment variable.
 
 ### Example playbook
 
@@ -40,7 +39,7 @@ environment variables.
         project_id: 216063
         region: "LT-Siauliai"
         plan: "B1-1-1gb-20s-shared"
-        auth_token: "my-auth-token-goes-here"
+        api_key: "my-api-key-goes-here"
 ```
 
 ## Included content

--- a/changelogs/fragments/api-key-param.yaml
+++ b/changelogs/fragments/api-key-param.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - Added `api_key` parameter to all modules (https://github.com/cherryservers/cherryctl/issues/73).
+deprecated_features:
+  - Deprecated `auth_token` in favor of `api_key` for all modules (https://github.com/cherryservers/cherryctl/issues/73).

--- a/changelogs/fragments/api-key-param.yaml
+++ b/changelogs/fragments/api-key-param.yaml
@@ -1,4 +1,4 @@
 minor_changes:
-  - Added `api_key` parameter to all modules (https://github.com/cherryservers/cherryctl/issues/73).
+  - Added `api_key` option across the collection (https://github.com/cherryservers/cherryctl/issues/73).
 deprecated_features:
-  - Deprecated `auth_token` in favor of `api_key` for all modules (https://github.com/cherryservers/cherryctl/issues/73).
+  - Deprecated `auth_token` in favor of `api_key` across the collection (https://github.com/cherryservers/cherryctl/issues/73).

--- a/plugins/doc_fragments/cherryservers.py
+++ b/plugins/doc_fragments/cherryservers.py
@@ -7,11 +7,15 @@
 class ModuleDocFragment:  # pylint: disable=missing-class-docstring, too-few-public-methods
     DOCUMENTATION = r"""
     options:
-      auth_token:
+      api_key:
         description:
-          - API authentication token for Cherry Servers public API.
-          - Can be supplied via E(CHERRY_AUTH_TOKEN) and E(CHERRY_AUTH_KEY) environment variables.
+          - API key for Cherry Servers public API.
+          - Can also be supplied via the E(CHERRY_API_KEY) environment variable.
+          - The alias C(auth_token) is B(deprecated) and will be removed in C(v4.0.0),
+            along with the environment variables E(CHERRY_AUTH_TOKEN) and E(CHERRY_AUTH_KEY).
         type: str
+        aliases: [auth_token]
+        required: true
 
     requirements:
       - python >= 3.11
@@ -20,7 +24,7 @@ class ModuleDocFragment:  # pylint: disable=missing-class-docstring, too-few-pub
       - name: Cherry Servers API documentation
         description: Complete reference for Cherry Servers public API.
         link: https://api.cherryservers.com/doc/
-      - name: Cherry Servers authentication token generation
-        description: Generate Cherry Servers API tokens.
+      - name: Cherry Servers API key generation
+        description: Generate Cherry Servers API keys.
         link: https://portal.cherryservers.com/settings/api-keys
     """

--- a/plugins/inventory/cherryservers.py
+++ b/plugins/inventory/cherryservers.py
@@ -26,13 +26,18 @@ options:
     choices: ['cherryservers.cloud.cherryservers']
   auth_token:
     description:
+      - B(Deprecated:) this option is deprecated and will be removed in C(v4.0.0), use O(api_key) instead.
       - API authentication token for Cherry Servers public API.
-      - Can be supplied via E(CHERRY_AUTH_TOKEN) and E(CHERRY_AUTH_KEY) environment variables.
     type: str
-    required: true
     env:
       - name: CHERRY_AUTH_TOKEN
       - name: CHERRY_AUTH_KEY
+  api_key:
+    description:
+      - API key for Cherry Servers public API.
+    type: str
+    env:
+      - name: CHERRY_API_KEY
   project_id:
     description:
       - ID of the project to get servers from.
@@ -64,12 +69,12 @@ EXAMPLES = """
 # Get all servers from a project.
 plugin: cherryservers.cloud.cherryservers
 project_id: 123456
-auth_token: "my_api_key"
+api_key: "my_api_key"
 
 # Get all servers from a specified region and that have the specified tags.
 plugin: cherryservers.cloud.cherryservers
 project_id: 123456
-auth_token: "my_api_key"
+api_key: "my_api_key"
 region: "LT-Siauliai"
 tags:
   env: "test"
@@ -77,7 +82,7 @@ tags:
 # Use grouping.
 plugin: cherryservers.cloud.cherryservers
 project_id: 123456
-auth_token: "my_api_key"
+api_key: "my_api_key"
 keyed_groups:
   - key: cs_region
     prefix: region
@@ -110,14 +115,19 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
         return valid
 
     def _get_inventory(self):
-        auth_token = self.get_option("auth_token")
-        auth_token = self.templar.template(auth_token)
+        api_key = self.get_option("api_key")
+        api_key = self.templar.template(api_key)
+
+        if not api_key:
+            # auth_token is deprecated
+            api_key = self.get_option("auth_token")
+            api_key = self.templar.template(api_key)
 
         project_id = self.get_option("project_id")
         project_id = self.templar.template(project_id)
 
         headers = {
-            "Authorization": f"Bearer {auth_token}",
+            "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
 

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -39,22 +39,22 @@ class CherryServersClient:  # pylint: disable=too-few-public-methods
         self._base_url = self._module.params.get(
             "base_url", CherryServersClient._base_url
         )
-        self._auth_token = self._module.params.get("api_key", None)
-        if self._auth_token is None:
+        self._api_key = self._module.params.get("api_key", None)
+        if self._api_key is None:
             self._module.fail_json(msg="auth_token/api_key not provided.")
 
         self._headers = {
-            "Authorization": f"Bearer {self._auth_token}",
+            "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
             "User-Agent": f"cherryservers-ansible/{_VERSION}",
         }
 
-        self._validate_auth_token()
+        self._validate_api_key()
 
-    def _validate_auth_token(self):
+    def _validate_api_key(self):
         status, _2 = self.send_request("GET", "user", 10)
         if status != 200:
-            self._module.fail_json(msg="Failed to validate auth_token/api-key.")
+            self._module.fail_json(msg="Failed to validate auth_token/api_key.")
 
     def send_request(
         self, method: str, url: str, timeout: int, **kwargs

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -23,12 +23,8 @@ from ._version import _VERSION
 class CherryServersClient:  # pylint: disable=too-few-public-methods
     """Cherry Server public API client.
 
-    Upon instantiation this class will attempt to validate
-    the provided Cherry Servers authentication token,
-    and will fail the ansible module if unable to do so.
-    This token can be set via the CHERRY_AUTH_TOKEN and
-    CHERRY_AUTH_KEY environment variables or passed as
-    an ansible module parameter.
+    Validates `api_key` and `base_url` module parameters by making a dummy
+    request.
 
     Methods:
 
@@ -43,9 +39,9 @@ class CherryServersClient:  # pylint: disable=too-few-public-methods
         self._base_url = self._module.params.get(
             "base_url", CherryServersClient._base_url
         )
-        self._auth_token = self._module.params.get("auth_token", None)
+        self._auth_token = self._module.params.get("api_key", None)
         if self._auth_token is None:
-            self._module.fail_json(msg="auth_token not provided.")
+            self._module.fail_json(msg="auth_token/api_key not provided.")
 
         self._headers = {
             "Authorization": f"Bearer {self._auth_token}",
@@ -58,7 +54,7 @@ class CherryServersClient:  # pylint: disable=too-few-public-methods
     def _validate_auth_token(self):
         status, _2 = self.send_request("GET", "user", 10)
         if status != 200:
-            self._module.fail_json(msg="Failed to validate auth token.")
+            self._module.fail_json(msg="Failed to validate auth_token/api-key.")
 
     def send_request(
         self, method: str, url: str, timeout: int, **kwargs

--- a/plugins/module_utils/module.py
+++ b/plugins/module_utils/module.py
@@ -37,9 +37,25 @@ class Module(ABC):
 def get_base_arg_spec() -> dict:
     """Return a dictionary with the base module argument spec."""
     return {
-        "auth_token": {
+        "api_key": {
             "type": "str",
             "no_log": True,
-            "fallback": (utils.env_fallback, ["CHERRY_AUTH_TOKEN", "CHERRY_AUTH_KEY"]),
+            "aliases": ["auth_token"],
+            "required": True,
+            "deprecated_aliases": [
+                {
+                    "name": "auth_token",
+                    "version": "4.0.0",
+                    "collection_name": "cherryservers.cloud",
+                },
+            ],
+            "fallback": (
+                utils.env_fallback,
+                [
+                    "CHERRY_API_KEY",
+                    "CHERRY_AUTH_TOKEN",
+                    "CHERRY_AUTH_KEY",
+                ],
+            ),
         },
     }

--- a/plugins/modules/floating_ip_info.py
+++ b/plugins/modules/floating_ip_info.py
@@ -59,19 +59,16 @@ author:
 EXAMPLES = r"""
 - name: Get single floating IP
   cherryservers.cloud.floating_ip_info:
-    auth_token: "{{ auth_token }}"
     id: "497f6eca-6276-4993-bfeb-53cbbbba6f08"
   register: result
 
 - name: Get all project floating IPs
   cherryservers.cloud.floating_ip_info:
-    auth_token: "{{ auth_token }}"
     project_id: 123456
   register: result
 
-- name: 'Get all floating IPs in the EU Nord-1 region, that have the env: dev tag'
+- name: 'Get all floating IPs in the LT-Siauliai region, that have the env: dev tag'
   cherryservers.cloud.floating_ip_info:
-    auth_token: "{{ auth_token }}"
     region: "LT-Siauliai"
     project_id: 123456
     tags:

--- a/plugins/modules/plan_info.py
+++ b/plugins/modules/plan_info.py
@@ -37,7 +37,6 @@ author:
 EXAMPLES = r"""
 - name: Get plans
   cherryservers.cloud.plan_info:
-    auth_token: "{{ auth_token }}"
     team_id: 123456
   register: result
 """

--- a/plugins/modules/prebuilt_info.py
+++ b/plugins/modules/prebuilt_info.py
@@ -48,7 +48,6 @@ author:
 EXAMPLES = r"""
 - name: Get a plan variations for amd-epyc-9355
   cherryservers.cloud.prebuilt_info:
-    auth_token: "{{ auth_token }}"
     team_id: 123456
     plan: "amd-epyc-9355"
     region: "LT-Siauliai"

--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -64,20 +64,17 @@ author:
 EXAMPLES = r"""
 - name: Create a project
   cherryservers.cloud.project:
-    auth_token: "{{ auth_token }}"
     name: 'ans-test'
     team_id: 148226
   register: result
 
 - name: Update project
   cherryservers.cloud.project:
-    auth_token: "{{ auth_token }}"
     name: "ans-test-updated"
     id: "{{ result.cherryservers_project.id }}"
 
 - name: Delete project
   cherryservers.cloud.project:
-    auth_token: "{{ auth_token }}"
     id: 123456
     state: absent
 """

--- a/plugins/modules/project_info.py
+++ b/plugins/modules/project_info.py
@@ -51,19 +51,16 @@ author:
 EXAMPLES = r"""
 - name: Get a project by ID
   cherryservers.cloud.project_info:
-    auth_token: "{{ auth_token }}"
     id: 123456
   register: result
 
 - name: Get all team projects
   cherryservers.cloud.project_info:
-    auth_token: "{{ auth_token }}"
     team_id: 123456
   register: result
 
 - name: Get all team projects that have BGP disabled
   cherryservers.cloud.project_info:
-    auth_token: "{{ auth_token }}"
     team_id: 123456
     bgp: False
   register: result

--- a/plugins/modules/sshkey.py
+++ b/plugins/modules/sshkey.py
@@ -62,7 +62,6 @@ author:
 EXAMPLES = r"""
 - name: Create SSH key
   cherryservers.cloud.sshkey:
-    auth_token: "{{ auth_token }}"
     label: "SSH-test-key"
     key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBYe+GfpsnLP02tfLOJWWFnGKJNpgrzLYE5VZhclrFy0 example@example.com"
     state: present
@@ -70,14 +69,12 @@ EXAMPLES = r"""
 
 - name: Update SSH key
   cherryservers.cloud.sshkey:
-    auth_token: "{{ auth_token }}"
     label: "SSH-test-key-updated"
     id: "{{ result.cherryservers_sshkey.id }}"
     state: present
 
 - name: Delete SSH key
   cherryservers.cloud.sshkey:
-    auth_token: "{{ auth_token }}"
     label: "SSH-test-key-updated"
     state: absent
 """

--- a/plugins/modules/sshkey_info.py
+++ b/plugins/modules/sshkey_info.py
@@ -52,13 +52,11 @@ author:
 EXAMPLES = r"""
 - name: Get SSH key by ID
   cherryservers.cloud.sshkey_info:
-    auth_token: "{{ auth_token }}"
     id: 0000
   register: result
 
 - name: Get SSH key by label
   cherryservers.cloud.sshkey_info:
-    auth_token: "{{ auth_token }}"
     label: "my-key"
   register: result
 """

--- a/plugins/modules/storage_info.py
+++ b/plugins/modules/storage_info.py
@@ -60,19 +60,16 @@ author:
 EXAMPLES = r"""
 - name: Get a storage volume by ID
   cherryservers.cloud.storage_info:
-    auth_token: "{{ auth_token }}"
     id: 123456
   register: result
 
 - name: Get all project storage volumes
   cherryservers.cloud.storage_info:
-    auth_token: "{{ auth_token }}"
     project_id: 123456
   register: result
 
 - name: Get all project storage volumes, that are detached and have test description
   cherryservers.cloud.storage_info:
-    auth_token: "{{ auth_token }}"
     project_id: 123456
     state: "detached"
     description: "test"

--- a/tests/integration/targets/auth_token/tasks/main.yml
+++ b/tests/integration/targets/auth_token/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Run tests
+  block:
+    # Regression test for deprecated api_key alias auth_token, can be removed in v4.0.0.
+    - name: Test plan info with auth_token
+      cherryservers.cloud.plan_info:
+        team_id: "{{ cherryservers_team_id }}"
+        auth_token: "{{ cherryservers_api_key }}"
+      register: plans
+      check_mode: true
+    - name: Verify info retrieval in check_mode
+      ansible.builtin.assert:
+        that:
+          - plans.cherryservers_plans | list | count >= 1
+          - plans is not changed

--- a/tests/integration/targets/floating_ip/tasks/test-basic-config.yml
+++ b/tests/integration/targets/floating_ip/tasks/test-basic-config.yml
@@ -3,7 +3,7 @@
   block:
     - name: create server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         region: "{{ fip_region }}"
         project_id: "{{ cherryservers_project_id }}"
         plan: "{{ server_plan }}"
@@ -15,7 +15,7 @@
 
     - name: test create floating ip missing parameter
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
       register: fip
       ignore_errors: true
@@ -26,7 +26,7 @@
 
     - name: test create floating ip with check mode
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         tags:
@@ -40,7 +40,7 @@
 
     - name: test no floating ip actually created
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         tags:
           env: "none"
@@ -53,7 +53,7 @@
 
     - name: test create floating ip
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
       register: fip
@@ -64,7 +64,7 @@
 
     - name: test floating ip actually created
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
     - name: verify floating ip actually created
@@ -76,7 +76,7 @@
 
     - name: test floating ip creation idempotency with check mode
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
@@ -89,7 +89,7 @@
 
     - name: test floating ip creation idempotency
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
@@ -102,7 +102,7 @@
     - name: test update floating ip with check mode
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         route_ip_id: "{{ server.cherryservers_server.ip_addresses[0].id }}"
@@ -118,7 +118,7 @@
 
     - name: test no floating ip update actually happened
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
@@ -134,7 +134,7 @@
     - name: test update floating ip
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         route_ip_id: "{{ server.cherryservers_server.ip_addresses[0].id }}"
@@ -149,7 +149,7 @@
 
     - name: test update floating ip actually happened
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
     - name: verify update floating ip actually happened
@@ -165,7 +165,7 @@
     - name: test floating ip update idempotency with check mode
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         route_ip_id: "{{ server.cherryservers_server.ip_addresses[0].id }}"
@@ -182,7 +182,7 @@
     - name: test server update idempotency
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         route_ip_id: "{{ server.cherryservers_server.ip_addresses[0].id }}"
@@ -197,7 +197,7 @@
 
     - name: test delete floating ip no id
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
       register: result
       ignore_errors: true
@@ -208,7 +208,7 @@
 
     - name: test delete floating ip with check mode
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -220,7 +220,7 @@
 
     - name: test no floating ip actually deleted
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
     - name: verify no floating ip actually deleted
@@ -230,7 +230,7 @@
 
     - name: test delete floating ip
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -244,7 +244,7 @@
         seconds: 10
     - name: test floating ip actually deleted
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
       ignore_errors: true
@@ -255,7 +255,7 @@
 
     - name: test floating ip delete idempotency with check mode
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -267,7 +267,7 @@
 
     - name: test floating ip delete idempotency
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -280,10 +280,10 @@
     - name: delete server
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
     - name: delete floating ip
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/floating_ip/tasks/test-full-config.yml
+++ b/tests/integration/targets/floating_ip/tasks/test-full-config.yml
@@ -3,7 +3,7 @@
   block:
     - name: create server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         region: "{{ fip_region }}"
         project_id: "{{ cherryservers_project_id }}"
         plan: "{{ server_plan }}"
@@ -15,7 +15,7 @@
 
     - name: test create floating ip missing parameter
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
       register: fip
       ignore_errors: true
@@ -26,7 +26,7 @@
 
     - name: test create floating ip with check mode
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "{{ server.cherryservers_server.id }}"
@@ -42,7 +42,7 @@
 
     - name: test no floating ip actually created
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         tags: "{{ fip_tags_full }}"
       register: result
@@ -54,7 +54,7 @@
 
     - name: test create floating ip
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "{{ server.cherryservers_server.id }}"
@@ -69,7 +69,7 @@
 
     - name: test floating ip actually created
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
     - name: verify floating ip actually created
@@ -86,7 +86,7 @@
     - name: test floating ip creation idempotency with check mode
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "{{ server.cherryservers_server.id }}"
@@ -103,7 +103,7 @@
     - name: test floating ip creation idempotency
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "{{ server.cherryservers_server.id }}"
@@ -119,7 +119,7 @@
     - name: test update floating ip with check mode
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "0"
@@ -135,7 +135,7 @@
 
     - name: test no floating ip update actually happened
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
@@ -151,7 +151,7 @@
     - name: test update floating ip
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "0"
@@ -166,7 +166,7 @@
 
     - name: test update floating ip actually happened
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
     - name: verify update floating ip actually happened
@@ -182,7 +182,7 @@
     - name: test floating ip update idempotency with check mode
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "0"
@@ -199,7 +199,7 @@
     - name: test server update idempotency
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ fip_region }}"
         target_server_id: "0"
@@ -214,7 +214,7 @@
 
     - name: test delete floating ip no id
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
       register: result
       ignore_errors: true
@@ -225,7 +225,7 @@
 
     - name: test delete floating ip with check mode
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -237,7 +237,7 @@
 
     - name: test no floating ip actually deleted
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
     - name: verify no floating ip actually deleted
@@ -247,7 +247,7 @@
 
     - name: test delete floating ip
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -261,7 +261,7 @@
         seconds: 10
     - name: test floating ip actually deleted
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
       ignore_errors: true
@@ -272,7 +272,7 @@
 
     - name: test floating ip delete idempotency with check mode
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -284,7 +284,7 @@
 
     - name: test floating ip delete idempotency
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
@@ -297,10 +297,10 @@
     - name: delete server
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
     - name: delete floating ip
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/floating_ip_info/tasks/main.yml
+++ b/tests/integration/targets/floating_ip_info/tasks/main.yml
@@ -3,14 +3,14 @@
   block:
     - name: create project
       cherryservers.cloud.project:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
         name: "ansible-test-fip-info"
       register: project
 
     - name: create server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         region: "{{ fip_region }}"
         project_id: "{{ project.cherryservers_project.id }}"
         plan: "{{ server_plan }}"
@@ -22,7 +22,7 @@
 
     - name: create fip
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         region: "{{ fip_region }}"
         project_id: "{{ project.cherryservers_project.id }}"
         target_server_id: "{{ server.cherryservers_server.id }}"
@@ -35,7 +35,7 @@
 
     - name: test gather by project_id
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
       register: result
     - name: verify gather by project_id
@@ -46,7 +46,7 @@
 
     - name: test gather by project_id with check mode
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
       check_mode: true
       register: result
@@ -58,7 +58,7 @@
 
     - name: test gather floating ip by id
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       register: result
     - name: verify gather floating ip by id
@@ -69,7 +69,7 @@
 
     - name: test gather floating ip by id with check mode
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ fip.cherryservers_floating_ip.id }}"
       check_mode: true
       register: result
@@ -81,7 +81,7 @@
 
     - name: test gather floating ip by id wrong
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "ef607e8a-d9d4-d4ba-7379-55dbd841e06c"
       register: result
       ignore_errors: true
@@ -92,7 +92,7 @@
 
     - name: test gather floating ip by address
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         address: "{{ fip.cherryservers_floating_ip.address }}"
       register: result
@@ -104,7 +104,7 @@
 
     - name: test gather floating ip by address with check mode
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         address: "{{ fip.cherryservers_floating_ip.address }}"
       register: result
@@ -117,7 +117,7 @@
 
     - name: test gather floating ip by server id
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         target_server_id: "{{ fip.cherryservers_floating_ip.target_server_id }}"
       register: result
@@ -129,7 +129,7 @@
 
     - name: test gather floating ip by tags
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         tags: "{{ fip_tags }}"
       register: result
@@ -141,7 +141,7 @@
 
     - name: test gather floating ip by tags with check mode
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         tags: "{{ fip_tags }}"
       check_mode: true
@@ -154,7 +154,7 @@
 
     - name: test gather floating ip by tags wrong
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         tags:
           env: "none"
@@ -167,7 +167,7 @@
 
     - name: test gather with all options
       cherryservers.cloud.floating_ip_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         address: "{{ fip.cherryservers_floating_ip.address }}"
         tags: "{{ fip.cherryservers_floating_ip.tags }}"
@@ -184,4 +184,4 @@
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
         state: "absent"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"

--- a/tests/integration/targets/plan_info/tasks/main.yml
+++ b/tests/integration/targets/plan_info/tasks/main.yml
@@ -4,7 +4,7 @@
     - name: Test info with wrong team_id
       cherryservers.cloud.plan_info:
         team_id: 0
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: plans
       ignore_errors: true
     - name: Verify failure when getting plan info with wrong team_id
@@ -15,7 +15,7 @@
     - name: Test info with check_mode
       cherryservers.cloud.plan_info:
         team_id: "{{ cherryservers_team_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: plans
       check_mode: true
     - name: Verify info retrieval in check_mode
@@ -27,7 +27,7 @@
     - name: Test info correct result
       cherryservers.cloud.plan_info:
         team_id: "{{ cherryservers_team_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: plans
     - name: Verify info result correct
       ansible.builtin.assert:

--- a/tests/integration/targets/prebuilt_info/tasks/main.yml
+++ b/tests/integration/targets/prebuilt_info/tasks/main.yml
@@ -6,7 +6,7 @@
         team_id: 0
         plan: "{{ base_plan }}"
         region: "{{ region }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: prebuilt
       ignore_errors: true
     - name: Verify failure when getting prebuilt info with wrong team_id
@@ -17,7 +17,7 @@
     - name: Test info with check_mode
       cherryservers.cloud.prebuilt_info:
         team_id: "{{ cherryservers_team_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         plan: "{{ base_plan }}"
         region: "{{ region }}"
       register: prebuilt
@@ -31,7 +31,7 @@
     - name: Test info correct result
       cherryservers.cloud.prebuilt_info:
         team_id: "{{ cherryservers_team_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         plan: "{{ base_plan }}"
         region: "{{ region }}"
       register: prebuilt

--- a/tests/integration/targets/prebuilt_server/tasks/main.yml
+++ b/tests/integration/targets/prebuilt_server/tasks/main.yml
@@ -3,7 +3,7 @@
   block:
     - name: List plans
       cherryservers.cloud.plan_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
       register: plans
 
@@ -33,7 +33,7 @@
 
     - name: List prebuilt plans
       cherryservers.cloud.prebuilt_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
         region: "{{ plan_stock[0].region }}"
         plan: "{{ plan_stock[0].slug }}"
@@ -56,14 +56,14 @@
 
     - name: Create project
       cherryservers.cloud.project:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
         name: "ansible-prebuilt-server-test"
       register: project
 
     - name: Test create prebuilt server with wrong prebuilt_id
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         region: "{{ plan_stock[0].region }}"
         plan: "{{ plan_stock[0].slug }}"
@@ -77,7 +77,7 @@
 
     - name: Test create prebuilt server with check mode
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         region: "{{ region }}"
         plan: "{{ base_plan }}"
@@ -91,7 +91,7 @@
 
     - name: Test no server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
       register: result
     - name: Verify no server actually created
@@ -101,7 +101,7 @@
 
     - name: Test create prebuilt server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
         region: "{{ region }}"
         plan: "{{ base_plan }}"
@@ -114,7 +114,7 @@
 
     - name: Test server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ project.cherryservers_project.id }}"
       register: result
     - name: Verify prebuilt server created
@@ -126,5 +126,5 @@
     - name: Delete the project
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/project/tasks/main.yml
+++ b/tests/integration/targets/project/tasks/main.yml
@@ -3,7 +3,7 @@
   block:
     - name: test create project missing parameter
       cherryservers.cloud.project:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
       register: project
       ignore_errors: true
@@ -14,7 +14,7 @@
 
     - name: test create project with check mode
       cherryservers.cloud.project:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
         name: "{{ project_name }}"
       register: project
@@ -26,7 +26,7 @@
 
     - name: test that no project actually created
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ project.cherryservers_project.id }}"
       register: result
       ignore_errors: true
@@ -37,7 +37,7 @@
 
     - name: test create project
       cherryservers.cloud.project:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
         name: "{{ project_name }}"
       register: project
@@ -48,7 +48,7 @@
 
     - name: test project actually created
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ project.cherryservers_project.id }}"
       register: result
     - name: verify that project actually created
@@ -59,7 +59,7 @@
 
     - name: test project creation idempotency with check mode
       cherryservers.cloud.project:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
         name: "{{ project_name }}"
       register: result
@@ -71,7 +71,7 @@
 
     - name: test project creation idempotency
       cherryservers.cloud.project:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
         name: "{{ project_name }}"
       register: result
@@ -85,7 +85,7 @@
         id: "{{ project.cherryservers_project.id }}"
         name: "{{ project_name_updated }}"
         bgp: True
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       check_mode: true
       register: result
     - name: verify project update with check mode
@@ -98,7 +98,7 @@
         bgp: True
         team_id: "{{ cherryservers_team_id }}"
         name: "{{ project_name_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify no update project actually happened
       ansible.builtin.assert:
@@ -111,7 +111,7 @@
         id: "{{ project.cherryservers_project.id }}"
         name: "{{ project_name_updated }}"
         bgp: True
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify project update
       ansible.builtin.assert:
@@ -123,7 +123,7 @@
         bgp: True
         name: "{{ project_name_updated }}"
         team_id: "{{ cherryservers_team_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify update project actually happened
       ansible.builtin.assert:
@@ -136,7 +136,7 @@
         id: "{{ project.cherryservers_project.id }}"
         name: "{{ project_name_updated }}"
         bgp: True
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
       check_mode: true
     - name: verify project update idempotency with check mode
@@ -149,7 +149,7 @@
         id: "{{ project.cherryservers_project.id }}"
         name: "{{ project_name_updated }}"
         bgp: True
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify project update idempotency
       ansible.builtin.assert:
@@ -161,7 +161,7 @@
         name: "{{ project_name_updated }}"
         bgp: False
         team_id: "{{ cherryservers_team_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify project update by name
       ansible.builtin.assert:
@@ -171,7 +171,7 @@
     - name: test delete project with check mode
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
       check_mode: true
@@ -183,7 +183,7 @@
     - name: test that no project actually deleted
       cherryservers.cloud.project_info:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify that no project actually deleted
       ansible.builtin.assert:
@@ -193,7 +193,7 @@
     - name: test delete project
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
     - name: verify delete project
@@ -204,7 +204,7 @@
     - name: test that project actually deleted
       cherryservers.cloud.project_info:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
       ignore_errors: true
     - name: verify that project actually deleted
@@ -215,7 +215,7 @@
     - name: test delete project idempotency with check mode
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
       check_mode: true
@@ -227,7 +227,7 @@
     - name: test delete project idempotency
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
     - name: verify delete project idempotency
@@ -239,5 +239,5 @@
     - name: delete test project
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/project_info/tasks/main.yml
+++ b/tests/integration/targets/project_info/tasks/main.yml
@@ -5,7 +5,7 @@
       cherryservers.cloud.project:
         name: "{{ project_name }}"
         team_id: "{{ cherryservers_team_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: project
     - name: verify create project
       ansible.builtin.assert:
@@ -14,7 +14,7 @@
 
     - name: test no options info gathering
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
       register: result
     - name: verify no options info gathering
@@ -25,7 +25,7 @@
 
     - name: test no options info gathering with check mode
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         team_id: "{{ cherryservers_team_id }}"
       check_mode: true
       register: result
@@ -37,7 +37,7 @@
 
     - name: test gather project by id
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ project.cherryservers_project.id }}"
       register: result
     - name: verify gather project by id
@@ -48,7 +48,7 @@
 
     - name: test gather project by id wrong
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "123456"
       register: result
       ignore_errors: true
@@ -59,7 +59,7 @@
 
     - name: test gather project by name
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         name: "{{ project.cherryservers_project.name }}"
         team_id: "{{ cherryservers_team_id }}"
       register: result
@@ -71,7 +71,7 @@
 
     - name: test gather project by name wrong
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         name: "{{ project.cherryservers_project.name }}wrong"
         team_id: "{{ cherryservers_team_id }}"
       register: result
@@ -83,7 +83,7 @@
 
     - name: test gather project with multiple options
       cherryservers.cloud.project_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ project.cherryservers_project.id }}"
         name: "{{ project.cherryservers_project.name }}"
         team_id: "{{ cherryservers_team_id }}"
@@ -98,7 +98,7 @@
       cherryservers.cloud.project:
         id: "{{ project.cherryservers_project.id }}"
         state: "absent"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify delete project
       ansible.builtin.assert:

--- a/tests/integration/targets/server/tasks/test-basic-config.yml
+++ b/tests/integration/targets/server/tasks/test-basic-config.yml
@@ -3,7 +3,7 @@
   block:
     - name: test create server missing parameter
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
       register: server
       ignore_errors: true
@@ -14,7 +14,7 @@
 
     - name: test create server with check mode
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -28,7 +28,7 @@
 
     - name: test no server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "test-server-none"
       register: result
@@ -40,7 +40,7 @@
 
     - name: test create server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -52,7 +52,7 @@
 
     - name: test server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
       register: result
     - name: verify server actually created
@@ -65,7 +65,7 @@
 
     - name: test server creation idempotency with check mode
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
       register: result
       check_mode: true
@@ -76,7 +76,7 @@
 
     - name: test server creation idempotency
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
       register: result
     - name: verify server creation idempotency
@@ -87,7 +87,7 @@
     - name: test update server with check mode
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_update_hostname }}"
         tags: "{{ server_update_tags }}"
       check_mode: true
@@ -100,7 +100,7 @@
     - name: test no server update actually happened
       cherryservers.cloud.server_info:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_update_hostname }}"
         tags: "{{ server_update_tags }}"
       register: result
@@ -113,7 +113,7 @@
     - name: test update server
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_update_hostname }}"
         tags: "{{ server_update_tags }}"
       register: result
@@ -125,7 +125,7 @@
     - name: test update server actually happened
       cherryservers.cloud.server_info:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_update_hostname }}"
         tags: "{{ server_update_tags }}"
       register: result
@@ -139,7 +139,7 @@
     - name: test server update idempotency with check mode
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_update_hostname }}"
         tags: "{{ server_update_tags }}"
       register: result
@@ -152,7 +152,7 @@
     - name: test server update idempotency
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_update_hostname }}"
         tags: "{{ server_update_tags }}"
       register: result
@@ -163,7 +163,7 @@
 
     - name: test delete server no id
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
       register: result
       ignore_errors: true
@@ -175,7 +175,7 @@
     - name: test delete server with check mode
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
       register: result
       check_mode: true
@@ -186,7 +186,7 @@
 
     - name: test no server actually deleted
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
       register: result
     - name: verify no server actually deleted
@@ -196,7 +196,7 @@
 
     - name: test delete server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
         state: "absent"
       register: result
@@ -207,7 +207,7 @@
 
     - name: test server actually deleted
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
       register: result
       ignore_errors: true
@@ -218,7 +218,7 @@
 
     - name: test server delete idempotency with check mode
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
         state: "absent"
       register: result
@@ -230,7 +230,7 @@
 
     - name: test server delete idempotency
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
         state: "absent"
       register: result
@@ -243,5 +243,5 @@
     - name: delete servers
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/server/tasks/test-full-config.yml
+++ b/tests/integration/targets/server/tasks/test-full-config.yml
@@ -5,7 +5,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ fake_key_label }}"
         key: "{{ fake_public_key }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: sshkey
     - name: verify create ssh key for server testing
       ansible.builtin.assert:
@@ -14,7 +14,7 @@
 
     - name: create floating ip for server testing
       cherryservers.cloud.floating_ip:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         region: "{{ server_region }}"
         project_id: "{{ cherryservers_project_id }}"
       register: fip
@@ -25,7 +25,7 @@
 
     - name: test create server with check mode
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -45,7 +45,7 @@
 
     - name: test no server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ server_hostname }}"
       register: result
@@ -57,7 +57,7 @@
 
     - name: test create server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -76,7 +76,7 @@
 
     - name: test server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
       register: result
     - name: verify server actually created
@@ -94,7 +94,7 @@
 
     - name: test server creation idempotency with check mode
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -113,7 +113,7 @@
 
     - name: test server creation idempotency
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -131,7 +131,7 @@
 
     - name: test reinstall server with no allow_reinstall
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_hostname }}"
         project_id: "{{ cherryservers_project_id }}"
         tags: "{{ server_update_tags }}"
@@ -147,7 +147,7 @@
 
     - name: test reinstall server with check mode
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ server_hostname }}"
         tags: "{{ server_update_tags }}"
@@ -165,7 +165,7 @@
     - name: test no server reinstall actually happened
       cherryservers.cloud.server_info:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_hostname }}"
         tags: "{{ server_update_tags }}"
         image: "{{ server_reinstall_image }}"
@@ -178,7 +178,7 @@
 
     - name: test reinstall server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_hostname }}"
         project_id: "{{ cherryservers_project_id }}"
         tags: "{{ server_update_tags }}"
@@ -194,7 +194,7 @@
 
     - name: test reinstall server actually happened
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ server_hostname }}"
         tags: "{{ server_update_tags }}"
@@ -211,7 +211,7 @@
     - name: test server reinstall idempotency with check mode
       cherryservers.cloud.server:
         project_id: "{{ cherryservers_project_id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         hostname: "{{ server_hostname }}"
         tags: "{{ server_update_tags }}"
         ssh_keys: [ "{{ sshkey.cherryservers_sshkey.id }}" ]
@@ -226,7 +226,7 @@
 
     - name: test server reinstall idempotency
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ server_hostname }}"
         tags: "{{ server_update_tags }}"
@@ -244,15 +244,15 @@
       cherryservers.cloud.server:
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ server_hostname }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
     - name: delete ssh key
       cherryservers.cloud.sshkey:
         id: "{{ sshkey.cherryservers_sshkey.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
     - name: delete floating ip
       cherryservers.cloud.floating_ip:
         id: "{{ fip.cherryservers_floating_ip.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/server/tasks/test-present-state.yml
+++ b/tests/integration/targets/server/tasks/test-present-state.yml
@@ -3,7 +3,7 @@
   block:
     - name: test create server missing parameter
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         state: "present"
       register: server
@@ -16,7 +16,7 @@
     - name: test create server with check mode
       cherryservers.cloud.server:
         state: "present"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         hostname: "ansible-test-present-server"
@@ -30,7 +30,7 @@
 
     - name: test no server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "ansible-test-present-server"
       register: result
@@ -43,7 +43,7 @@
     - name: test create server
       cherryservers.cloud.server:
         state: "present"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -55,7 +55,7 @@
 
     - name: test server actually created
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ server.cherryservers_server.id }}"
       register: result
     - name: verify server actually created
@@ -70,7 +70,7 @@
       cherryservers.cloud.server:
         state: "present"
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -85,7 +85,7 @@
       cherryservers.cloud.server:
         state: "present"
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ server_region }}"
         plan: "{{ server_plan }}"
@@ -99,5 +99,5 @@
     - name: delete servers
       cherryservers.cloud.server:
         id: "{{ server.cherryservers_server.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/server_info/tasks/main.yml
+++ b/tests/integration/targets/server_info/tasks/main.yml
@@ -3,7 +3,7 @@
   block:
     - name: create first server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         region: "{{ server_region }}"
         project_id: "{{ cherryservers_project_id }}"
         plan: "{{ server_plan }}"
@@ -17,7 +17,7 @@
 
     - name: create second server
       cherryservers.cloud.server:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         region: "{{ server_region }}"
         project_id: "{{ cherryservers_project_id }}"
         plan: "{{ server_plan }}"
@@ -31,7 +31,7 @@
 
     - name: test gather by project_id
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
       register: result
     - name: verify gather by project_id
@@ -42,7 +42,7 @@
 
     - name: test gather by project_id with check mode
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
       check_mode: true
       register: result
@@ -54,7 +54,7 @@
 
     - name: test gather server by id
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ first_server.cherryservers_server.id }}"
       register: result
     - name: verify gather server by id
@@ -65,7 +65,7 @@
 
     - name: test gather server by id with check mode
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ first_server.cherryservers_server.id }}"
       check_mode: true
       register: result
@@ -77,7 +77,7 @@
 
     - name: test gather server by id wrong
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "1234"
       register: result
       ignore_errors: true
@@ -88,7 +88,7 @@
 
     - name: test gather server by hostname
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ second_server.cherryservers_server.hostname }}"
       register: result
@@ -100,7 +100,7 @@
 
     - name: test gather server by hostname with check mode
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ second_server.cherryservers_server.hostname }}"
       check_mode: true
@@ -113,7 +113,7 @@
 
     - name: test gather server by hostname wrong
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "none"
       register: result
@@ -125,7 +125,7 @@
 
     - name: test gather server by tags
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         tags: "{{ server_tags }}"
       register: result
@@ -137,7 +137,7 @@
 
     - name: test gather server by tags with check mode
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         tags: "{{ server_tags }}"
       check_mode: true
@@ -150,7 +150,7 @@
 
     - name: test gather server by tags wrong
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         tags:
           env: "none"
@@ -163,7 +163,7 @@
 
     - name: test gather multiple options
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         tags: "{{ server_tags }}"
         project_id: "{{ cherryservers_project_id }}"
         hostname: "{{ second_server.cherryservers_server.hostname }}"
@@ -176,7 +176,7 @@
 
     - name: test gather with all options
       cherryservers.cloud.server_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         plan: "{{ second_server.cherryservers_server.plan }}"
         image: "{{ second_server.cherryservers_server.image }}"
@@ -195,7 +195,7 @@
       cherryservers.cloud.server:
         id: "{{ first_server.cherryservers_server.id }}"
         state: "absent"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify delete first server
       ansible.builtin.assert:
@@ -206,7 +206,7 @@
       cherryservers.cloud.server:
         id: "{{ second_server.cherryservers_server.id }}"
         state: "absent"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify delete second server
       ansible.builtin.assert:

--- a/tests/integration/targets/sshkey/tasks/main.yml
+++ b/tests/integration/targets/sshkey/tasks/main.yml
@@ -4,7 +4,7 @@
     - name: test create ssh key missing parameter
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: first_sshkey
       ignore_errors: true
     - name: verify create ssh key missing parameter
@@ -16,7 +16,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: first_sshkey
       check_mode: true
     - name: verify create ssh key with check mode
@@ -28,7 +28,7 @@
       cherryservers.cloud.sshkey_info:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify that no ssh key actually created
       ansible.builtin.assert:
@@ -40,7 +40,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: first_sshkey
     - name: verify create ssh key
       ansible.builtin.assert:
@@ -51,7 +51,7 @@
       cherryservers.cloud.sshkey_info:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify ssh key actually created
       ansible.builtin.assert:
@@ -62,7 +62,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
       check_mode: true
     - name: verify key creation idempotency with check mode
@@ -74,7 +74,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify key creation idempotency
       ansible.builtin.assert:
@@ -85,7 +85,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_2 }}"
         key: "{{ fake_public_key_2 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: second_sshkey
     - name: verify second ssh key
       ansible.builtin.assert:
@@ -96,7 +96,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_2 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
       ignore_errors: true
     - name: verify fail cleanly on update ambiguity
@@ -109,7 +109,7 @@
         id: "{{ first_sshkey.cherryservers_sshkey.id }}"
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       check_mode: true
       register: result
     - name: verify update ssh key with check mode
@@ -121,7 +121,7 @@
       cherryservers.cloud.sshkey_info:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify no update actually happened
       ansible.builtin.assert:
@@ -134,7 +134,7 @@
         id: "{{ first_sshkey.cherryservers_sshkey.id }}"
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify update ssh key
       ansible.builtin.assert:
@@ -145,7 +145,7 @@
       cherryservers.cloud.sshkey_info:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify update actually happened
       ansible.builtin.assert:
@@ -157,7 +157,7 @@
         id: "{{ first_sshkey.cherryservers_sshkey.id }}"
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
       check_mode: true
     - name: verify key update idempotency with check mode
@@ -170,7 +170,7 @@
         id: "{{ first_sshkey.cherryservers_sshkey.id }}"
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify key update idempotency
       ansible.builtin.assert:
@@ -179,7 +179,7 @@
 
     - name: test delete keys no params
       cherryservers.cloud.sshkey:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
     - name: verify delete keys no params
@@ -191,7 +191,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
       check_mode: true
@@ -204,7 +204,7 @@
       cherryservers.cloud.sshkey_info:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify that no ssh key actually deleted
       ansible.builtin.assert:
@@ -215,7 +215,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
     - name: verify delete ssh key
@@ -227,7 +227,7 @@
       cherryservers.cloud.sshkey_info:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify ssh key actually deleted
       ansible.builtin.assert:
@@ -239,7 +239,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
       check_mode: true
@@ -252,7 +252,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_updated }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
     - name: verify key delete idempotency with check mode
@@ -266,7 +266,7 @@
         label: "{{ key_label_1 }}_updated"
         key: "{{ fake_public_key_2 }}"
         id: "{{ first_sshkey.cherryservers_sshkey.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent
       register: result
     - name: verify delete test keys

--- a/tests/integration/targets/sshkey_info/tasks/main.yml
+++ b/tests/integration/targets/sshkey_info/tasks/main.yml
@@ -5,7 +5,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
         key: "{{ fake_public_key_1 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: first_key
     - name: verify create first ssh key
       ansible.builtin.assert:
@@ -16,7 +16,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_2 }}"
         key: "{{ fake_public_key_2 }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: second_key
     - name: verify create second ssh key
       ansible.builtin.assert:
@@ -25,7 +25,7 @@
 
     - name: test no options info gathering
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify no options info gathering
       ansible.builtin.assert:
@@ -35,7 +35,7 @@
 
     - name: test no options info gathering with check mode
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       check_mode: true
       register: result
     - name: verify no options info gathering
@@ -46,7 +46,7 @@
 
     - name: test gather key by id
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ first_key.cherryservers_sshkey.id }}"
       register: result
     - name: verify gather key by id
@@ -57,7 +57,7 @@
 
     - name: test gather key by id wrong
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "1234"
       register: result
       ignore_errors: true
@@ -68,7 +68,7 @@
 
     - name: test gather key by fingerprint
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         fingerprint: "{{ first_key.cherryservers_sshkey.fingerprint }}"
       register: result
     - name: verify gather key by fingerprint
@@ -79,7 +79,7 @@
 
     - name: test gather key by fingerprint wrong
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         fingerprint: "{{ first_key.cherryservers_sshkey.fingerprint }}bad"
       register: result
     - name: verify gather key by fingerprint wrong
@@ -90,7 +90,7 @@
 
     - name: test gather key by label
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         label: "{{ first_key.cherryservers_sshkey.label }}"
       register: result
     - name: verify gather key by label
@@ -101,7 +101,7 @@
 
     - name: test gather key by label wrong
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         label: "{{ first_key.cherryservers_sshkey.label }}bad"
       register: result
     - name: verify gather key by label wrong
@@ -112,7 +112,7 @@
 
     - name: test gather key by public_key
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         key: "{{ first_key.cherryservers_sshkey.key }}"
       register: result
     - name: verify gather key by public_key
@@ -123,7 +123,7 @@
 
     - name: test gather key by public_key wrong
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         key: "{{ first_key.cherryservers_sshkey.key }}bad"
       register: result
     - name: verify gather key by public_key wrong
@@ -134,7 +134,7 @@
 
     - name: test gather multiple options
       cherryservers.cloud.sshkey_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ first_key.cherryservers_sshkey.id }}"
         fingerprint: "{{ second_key.cherryservers_sshkey.fingerprint }}"
       register: result
@@ -148,7 +148,7 @@
       cherryservers.cloud.sshkey:
         label: "{{ key_label_1 }}"
         state: "absent"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify delete ssh keys
       ansible.builtin.assert:
@@ -159,7 +159,7 @@
       cherryservers.cloud.sshkey:
         key: "{{ fake_public_key_2 }}"
         state: "absent"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
     - name: verify delete ssh keys
       ansible.builtin.assert:

--- a/tests/integration/targets/storage/tasks/main.yml
+++ b/tests/integration/targets/storage/tasks/main.yml
@@ -3,7 +3,7 @@
   block:
     - name: test create storage with missing parameters
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ storage_region }}"
       register: storage
@@ -15,7 +15,7 @@
 
     - name: test create storage with check mode
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ storage_region }}"
         target_server_id: "{{ cherryservers_baremetal_server_id }}"
@@ -30,7 +30,7 @@
 
     - name: test no storage actually created
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         description: "{{ storage_description }}"
         target_server_id: " {{ cherryservers_baremetal_server_id }}"
@@ -42,7 +42,7 @@
 
     - name: test create storage
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ storage_region }}"
         target_server_id: "{{ cherryservers_baremetal_server_id }}"
@@ -56,7 +56,7 @@
 
     - name: test storage actually created
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ storage.cherryservers_storage.id }}"
       register: result
     - name: verify storage actually created
@@ -71,7 +71,7 @@
 
     - name: test create storage idempotency with check mode
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ storage.cherryservers_storage.id }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ storage_region }}"
@@ -87,7 +87,7 @@
 
     - name: test create storage idempotency
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ storage.cherryservers_storage.id }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ storage_region }}"
@@ -103,7 +103,7 @@
     - name: test update storage with check mode
       cherryservers.cloud.storage:
         id: "{{ storage.cherryservers_storage.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         description: "{{ storage_updated_description }}"
         size: "{{ storage_updated_size }}"
         state: "detached"
@@ -116,7 +116,7 @@
 
     - name: test storage is not updated
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ storage.cherryservers_storage.id }}"
       register: result
     - name: verify storage is not updated
@@ -129,7 +129,7 @@
     - name: test update storage
       cherryservers.cloud.storage:
         id: "{{ storage.cherryservers_storage.id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         description: "{{ storage_updated_description }}"
         size: "{{ storage_updated_size }}"
         state: "detached"
@@ -146,7 +146,7 @@
 
     - name: test storage is updated
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         description: "{{ storage_updated_description }}"
       register: updated_storage
@@ -160,7 +160,7 @@
     - name: test update storage idempotency with check mode
       cherryservers.cloud.storage:
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         description: "{{ storage_updated_description }}"
         size: "{{ storage_updated_size }}"
         state: "detached"
@@ -174,7 +174,7 @@
     - name: test update storage idempotency
       cherryservers.cloud.storage:
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         description: "{{ storage_updated_description }}"
         size: "{{ storage_updated_size }}"
         state: "detached"
@@ -187,7 +187,7 @@
     - name: test attach storage
       cherryservers.cloud.storage:
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         target_server_id: "{{ cherryservers_baremetal_server_id }}"
       register: result
     - name: verify attach storage
@@ -197,7 +197,7 @@
 
     - name: test storage is attached
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
       register: result
     - name: verify storage is attached
@@ -207,7 +207,7 @@
 
     - name: test delete storage without id
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
       register: result
       ignore_errors: true
@@ -218,7 +218,7 @@
 
     - name: test delete storage with check mode
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
       register: result
@@ -230,7 +230,7 @@
 
     - name: test no storage actually deleted
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
       register: result
     - name: verify no storage actually deleted
@@ -240,7 +240,7 @@
 
     - name: test delete storage
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
       register: result
@@ -251,7 +251,7 @@
 
     - name: test storage actually deleted
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
       register: result
       ignore_errors: true
@@ -262,7 +262,7 @@
 
     - name: test storage delete idempotency with check mode
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
       register: result
@@ -274,7 +274,7 @@
 
     - name: test storage delete idempotency
       cherryservers.cloud.storage:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "absent"
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
       register: result
@@ -287,5 +287,5 @@
     - name: delete storage
       cherryservers.cloud.storage:
         id: "{{ updated_storage.cherryservers_storages[0].id }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: absent

--- a/tests/integration/targets/storage_info/tasks/main.yml
+++ b/tests/integration/targets/storage_info/tasks/main.yml
@@ -8,7 +8,7 @@
         size: "{{ storage_size }}"
         state: "detached"
         description: "{{ storage_description }}"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: storage
     - name: verify create storage
       ansible.builtin.assert:
@@ -17,7 +17,7 @@
 
     - name: test gather with no params
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result
       ignore_errors: true
     - name: verify no options info gathering
@@ -27,7 +27,7 @@
 
     - name: test gather by project id
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
       register: result
     - name: verify gather by project id
@@ -38,7 +38,7 @@
 
     - name: test gather by project id with check mode
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
       register: result
       check_mode: true
@@ -50,7 +50,7 @@
 
     - name: test gather with all params
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "detached"
         id: "{{ storage.cherryservers_storage.id }}"
         description: "{{ storage_description  }}"
@@ -65,7 +65,7 @@
 
     - name: test gather with all params with check mode
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "detached"
         id: "{{ storage.cherryservers_storage.id }}"
         description: "{{ storage_description  }}"
@@ -81,7 +81,7 @@
 
     - name: test gather with wrong id
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         id: "1"
       register: result
       ignore_errors: true
@@ -92,7 +92,7 @@
 
     - name: test gather by region
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         project_id: "{{ cherryservers_project_id }}"
         region: "{{ storage_region }}"
       register: result
@@ -104,7 +104,7 @@
 
     - name: test gather with detached state
       cherryservers.cloud.storage_info:
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
         state: "detached"
         project_id: "{{ cherryservers_project_id }}"
       register: result
@@ -119,5 +119,5 @@
       cherryservers.cloud.storage:
         id: "{{ storage.cherryservers_storage.id }}"
         state: "absent"
-        auth_token: "{{ cherryservers_api_key }}"
+        api_key: "{{ cherryservers_api_key }}"
       register: result


### PR DESCRIPTION
Add the option `api_key` while deprecating `auth_token` in favor of it in all modules and the inventory plugin.