### PR TITLE
chore: add "docs" to ignored patterns for collection building

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -57,7 +57,7 @@ issues: https://github.com/cherryservers/ansible-collection-cherryservers/issues
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
 # uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
 # and '.git' are always filtered. Mutually exclusive with 'manifest'
-build_ignore: ["bin", ".venv", "playbooks", ".idea", "venv"]
+build_ignore: ["bin", ".venv", "playbooks", ".idea", "venv", "docs"]
 
 # A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
 # list of MANIFEST.in style


### PR DESCRIPTION
This excludes the "docs" directory from the built collection, which is convenient when we want to generate documentation during local development, since the generated docs don't pass sanity tests.